### PR TITLE
Adds override for assertion check 

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -111,6 +111,10 @@ def _get_saml_client(domain):
     if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
         saml_settings['service']['sp']['name_id_format'] = settings.SAML2_AUTH['NAME_ID_FORMAT']
 
+    if 'WANT_ASSERTIONS_SIGNED' in settings.SAML2_AUTH:
+        saml_settings['service']['sp']['want_assertions_signed']: settings.SAML2_AUTH.get('WANT_ASSERTIONS_SIGNED', True)
+    
+
     spConfig = Saml2Config()
     spConfig.load(saml_settings)
     spConfig.allow_unknown_attributes = True


### PR DESCRIPTION
This change will allow us to set the `want_assertions_signed` to be whatever we want by environments within the Explore applications. Right now we have two different settings for Heroku and Azure, and would like the settings not to interfere with how our applications perform our SAML authentications. 